### PR TITLE
Use env command to locate php executable path for compatibility

### DIFF
--- a/src/Core/Asterisk/Configs/DialplanApplicationConf.php
+++ b/src/Core/Asterisk/Configs/DialplanApplicationConf.php
@@ -102,7 +102,7 @@ class DialplanApplicationConf extends AsteriskConfigClass
         $agiBinDir = $this->config->path('asterisk.astagidir');
 
         // Create PHP script file for the application
-        $text_app     = "#!/usr/bin/php\n";
+        $text_app     = "#!/usr/bin/env -S php -f\n";
         $text_app     .= base64_decode($app['applicationlogic']);
         file_put_contents("$agiBinDir/{$app['uniqid']}.php", $text_app);
         chmod("$agiBinDir/{$app['uniqid']}.php", 0755);

--- a/src/Core/Asterisk/agi-bin/cdr_connector.php
+++ b/src/Core/Asterisk/agi-bin/cdr_connector.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env -S php -f
 <?php
 
 /*

--- a/src/Core/Asterisk/agi-bin/check_redirect.php
+++ b/src/Core/Asterisk/agi-bin/check_redirect.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/Asterisk/agi-bin/get_park_info.php
+++ b/src/Core/Asterisk/agi-bin/get_park_info.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/bootup
+++ b/src/Core/System/RootFS/etc/rc/bootup
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/bootup_pbx
+++ b/src/Core/System/RootFS/etc/rc/bootup_pbx
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/connect_storage
+++ b/src/Core/System/RootFS/etc/rc/connect_storage
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/connect_swap
+++ b/src/Core/System/RootFS/etc/rc/connect_swap
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/console_menu
+++ b/src/Core/System/RootFS/etc/rc/console_menu
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/debian/mikopbx_lan_dhcp
+++ b/src/Core/System/RootFS/etc/rc/debian/mikopbx_lan_dhcp
@@ -11,6 +11,6 @@ case "${reason}" in BOUND|RENEW|REBIND|REBOOT)
     }
 
     # Execute PHP script with specific configuration based on the lease event
-    /usr/bin/php -f /etc/rc/udhcpc_configure "${reason}"
+    /usr/bin/env -S php -f /etc/rc/udhcpc_configure "${reason}"
 ;;
 esac

--- a/src/Core/System/RootFS/etc/rc/initial_install
+++ b/src/Core/System/RootFS/etc/rc/initial_install
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/initial_recovery
+++ b/src/Core/System/RootFS/etc/rc/initial_recovery
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/mountconfdir
+++ b/src/Core/System/RootFS/etc/rc/mountconfdir
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/networking
+++ b/src/Core/System/RootFS/etc/rc/networking
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/etc/rc/udhcpc_configure
+++ b/src/Core/System/RootFS/etc/rc/udhcpc_configure
@@ -1,4 +1,4 @@
-#!/usr/bin/php -f
+#!/usr/bin/env -S php -f
 <?php
 /*
  * MikoPBX - free phone system for small business

--- a/src/Core/System/RootFS/sbin/pbx-console
+++ b/src/Core/System/RootFS/sbin/pbx-console
@@ -85,7 +85,7 @@ services)
    start-all)
      # If safe script exists, start it
      if [ -f "$safeScript" ]; then
-       /usr/bin/php -f "$safeScript" start
+       /usr/bin/env -S php -f "$safeScript" start
      else
         echo 'Safe script not found.';
      fi
@@ -93,7 +93,7 @@ services)
    restart-all)
      # If safe script exists, restart it
      if [ -f "$safeScript" ]; then
-       /usr/bin/php -f "$safeScript" restart
+       /usr/bin/env -S php -f "$safeScript" restart
      else
         echo 'Safe script not found.';
      fi

--- a/src/Core/System/RootFS/sbin/voicemail-sender
+++ b/src/Core/System/RootFS/sbin/voicemail-sender
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env -S php -f
 <?php
 
 use MikoPBX\Common\Models\Extensions;

--- a/tests/Calls/db/updateDb.php
+++ b/tests/Calls/db/updateDb.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env -S php -f
 <?php
 require_once 'Globals.php';
 $dbUpdater = new \MikoPBX\Core\System\Upgrade\UpdateDatabase();

--- a/tests/Calls/start.sh
+++ b/tests/Calls/start.sh
@@ -81,7 +81,7 @@ fi
 
 tests="$initTests $tests"
 for file in $tests; do
-  /usr/bin/timeout 300 /usr/bin/php -f "${file}";
+  /usr/bin/timeout 300 /usr/bin/env -S php -f "${file}";
 done
 
 if [ ! "${2}x" == "x" ]; then


### PR DESCRIPTION
In php official Docker image php executable path is `/usr/local/bin/php`.

For compatibility `/usr/bin/php` / `/usr/bin/php -f` should be changed into `/usr/bin/env php` / `/usr/bin/env -S php -f`.

I fixed them with:

```bash
grep -lr '/usr/bin/php' | xargs sed -r -i 's;/usr/bin/php( -f)?;/usr/bin/env -S php -f;'
```