### PR TITLE
fix(oauth2): use HTTP origin from session context for callback URL

### DIFF
--- a/src/Core/System/Mail/MailOAuth2Service.php
+++ b/src/Core/System/Mail/MailOAuth2Service.php
@@ -66,12 +66,13 @@ class MailOAuth2Service
      * Generate OAuth2 authorization URL
      *
      * @param string $provider Provider name
+     * @param string|null $origin Origin URL from HTTP context (e.g., "https://pbx.example.com:8443")
      * @return string Authorization URL
      */
-    public static function generateAuthUrl(string $provider): string
+    public static function generateAuthUrl(string $provider, ?string $origin = null): string
     {
         try {
-            $providerInstance = self::getProvider($provider);
+            $providerInstance = self::getProvider($provider, $origin);
 
             if ($providerInstance === null) {
                 return '';
@@ -214,9 +215,10 @@ class MailOAuth2Service
      * Get OAuth2 provider instance
      *
      * @param string $provider Provider name
+     * @param string|null $origin Origin URL from HTTP context for redirect URI generation
      * @return AbstractProvider|null Provider instance
      */
-    private static function getProvider(string $provider): ?AbstractProvider
+    private static function getProvider(string $provider, ?string $origin = null): ?AbstractProvider
     {
         $clientId = PbxSettings::getValueByKey(PbxSettings::MAIL_OAUTH2_CLIENT_ID);
         $clientSecret = PbxSettings::getValueByKey(PbxSettings::MAIL_OAUTH2_CLIENT_SECRET);
@@ -226,7 +228,7 @@ class MailOAuth2Service
             return null;
         }
 
-        $redirectUri = self::getRedirectUri();
+        $redirectUri = self::getRedirectUri($origin);
         SystemMessages::sysLogMsg(__METHOD__, "OAuth2 config - Provider: {$provider}, ClientId: {$clientId}, RedirectUri: {$redirectUri}", LOG_INFO);
 
         switch ($provider) {
@@ -300,18 +302,26 @@ class MailOAuth2Service
     /**
      * Get redirect URI for OAuth2
      *
+     * @param string|null $origin Origin URL from HTTP context (e.g., "https://pbx.example.com:8443")
      * @return string Redirect URI
      */
-    private static function getRedirectUri(): string
+    private static function getRedirectUri(?string $origin = null): string
     {
-        // Get PBX external URL
+        // Try to use origin from HTTP context first (passed from controller via worker)
+        // This is the most reliable source since it comes from the actual HTTP request
+        if (!empty($origin)) {
+            // Origin is already in format "https://host:port", just append the callback path
+            return rtrim($origin, '/') . '/pbxcore/api/v3/mail-settings/oauth2-callback';
+        }
+
+        // Fallback to PBX settings
         $externalHost = PbxSettings::getValueByKey(PbxSettings::EXTERNAL_SIP_HOST_NAME);
         if (empty($externalHost)) {
             $externalHost = PbxSettings::getValueByKey(PbxSettings::EXTERNAL_SIP_IP_ADDR);
         }
 
         if (empty($externalHost)) {
-            // Fallback to current request host if available
+            // Last resort fallback to current request host if available (unlikely in worker context)
             if (isset($_SERVER['HTTP_HOST'])) {
                 $externalHost = $_SERVER['HTTP_HOST'];
             } else {

--- a/src/PBXCoreREST/Lib/MailSettings/GetOAuth2UrlAction.php
+++ b/src/PBXCoreREST/Lib/MailSettings/GetOAuth2UrlAction.php
@@ -70,7 +70,9 @@ class GetOAuth2UrlAction
             }
 
             // Generate authorization URL
-            $authUrl = MailOAuth2Service::generateAuthUrl($provider);
+            // Pass origin from HTTP context for callback URL generation
+            $origin = $data['origin'] ?? null;
+            $authUrl = MailOAuth2Service::generateAuthUrl($provider, $origin);
 
             if (empty($authUrl)) {
                 $res->messages['error'][] = 'Failed to generate OAuth2 authorization URL';

--- a/src/PBXCoreREST/Lib/MailSettingsManagementProcessor.php
+++ b/src/PBXCoreREST/Lib/MailSettingsManagementProcessor.php
@@ -85,7 +85,13 @@ class MailSettingsManagementProcessor extends Injectable
         $res->processor = __METHOD__;
 
         $actionString = $request['action'];
-        $data = $request['data'];
+        $data = $request['data'] ?? [];
+
+        // Add origin from session context for OAuth2 callback URL generation
+        // Worker runs in CLI context without $_SERVER['HTTP_HOST'], so we pass it from HTTP context
+        if (!empty($request['sessionContext']['origin'])) {
+            $data['origin'] = $request['sessionContext']['origin'];
+        }
 
         // Type-safe action matching with enum
         $action = MailSettingsAction::tryFrom($actionString);


### PR DESCRIPTION
OAuth2 callback URL was incorrectly using 127.0.0.1 because the code
runs in WorkerApiCommands (CLI context) where $_SERVER['HTTP_HOST']
is not available.

Fixed by passing origin from sessionContext (already contains scheme
and host from the HTTP request) through the processor to the OAuth2
service for redirect URI generation.

Changes:
- MailSettingsManagementProcessor: extract origin from sessionContext
- GetOAuth2UrlAction: pass origin to MailOAuth2Service
- MailOAuth2Service: use origin as primary source for redirect URI