### PR TITLE
fix id pattern check

### DIFF
--- a/src/PBXCoreREST/Services/ApiKeyPermissionChecker.php
+++ b/src/PBXCoreREST/Services/ApiKeyPermissionChecker.php
@@ -271,10 +271,10 @@ class ApiKeyPermissionChecker
             return true;
         }
 
-        // MikoPBX prefixed ID pattern: UPPERCASE-digits
-        // Examples: SIP-201, IAX-100, EXTENSION-123, CONFERENCE-ROOM-1
-        // Must have at least one uppercase letter, a hyphen, and end with digits
-        if (preg_match('/^[A-Z]+-.*\d+$/', $segment)) {
+        // MikoPBX prefixed ID pattern: UPPERCASE-digits(HEX)
+        // Examples: SIP-201, IAX-100, EXTENSION-123, CONFERENCE-ROOM-1, SIP-TRUNK-DEADC0DE
+        // Must have at least one uppercase letter, a hyphen, and end with digits or uppercase A-F letters
+        if (preg_match('/^(?:[A-Z]+-)+[A-F0-9]+$/', $segment)) {
             return true;
         }
 


### PR DESCRIPTION

## Summary

Updated regex pattern to include uppercase A-F letters in MikoPBX prefixed ID validation.

This took a while to find...
what happend was:
```sh
curl -v \
  -H "Authorization: Bearer APIKEY" \
  "http://HOST/pbxcore/api/v3/providers/SIP-TRUNK-6E389D95:getStatus"
```
worked but
```sh
curl -v \
  -H "Authorization: Bearer APIKEY" \
  "http://HOST/pbxcore/api/v3/providers/SIP-TRUNK-4BAD561B:getStatus"
```
did not, with http status 401.

root cause:
regex checks if the id ends with a digit, but the [generateUniqueID](https://github.com/mikopbx/Core/blob/bc4875c4a965d63c9c54387cbeaa452c4d2b0b80/src/Common/Models/ModelsBase.php#L582) generates a hexadecimal string which may contain a letter instead of a digit at the end and the regex fails.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (describe below)

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Changes Made

<!-- List the key changes -->

- fix regex to check for hexadecimal suffix id instead of a decimal one 

## Testing

tested using given curl commands above

- [ ] Tested in Docker container
- [X] Tested in VM (ISO)
- [X] Tested via REST API
- [ ] Tested via web interface
- [ ] Added/updated tests

## Checklist

- [X] Code follows the project's [coding standards](CONTRIBUTING.md)
- [ ] PHPStan analysis passes
- [ ] phpcs (PSR-12) passes
- [ ] No new warnings or errors in logs
- [X] Self-reviewed the code
