### PR TITLE
Fix fail2ban whitelist CIDR handling

### DIFF
--- a/src/Core/System/Configs/Fail2BanConf.php
+++ b/src/Core/System/Configs/Fail2BanConf.php
@@ -795,7 +795,7 @@ class Fail2BanConf extends SystemConfigClass
 
             // Verify and add each IP to user whitelist.
             foreach ($arr_whitelist as $ip_string) {
-                if (Verify::isIpAddress($ip_string)) {
+                if (self::isValidIgnoreIpEntry($ip_string)) {
                     $user_whitelist .= "$ip_string ";
                 }
             }
@@ -860,6 +860,16 @@ class Fail2BanConf extends SystemConfigClass
             default:
                 echo "Invalid action: $action\n";
         }
+    }
+
+    private static function isValidIgnoreIpEntry(string $value): bool
+    {
+        if (Verify::isIpAddress($value)) {
+            return true;
+        }
+
+        return preg_match('#^(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}$#', $value) === 1
+            || preg_match('#^[0-9a-fA-F:]+/\d{1,3}$#', $value) === 1;
     }
 
     /**


### PR DESCRIPTION
## Summary
Fix Fail2Ban whitelist handling for CIDR subnets when generating `ignoreip` in `/etc/fail2ban/jail.local`.

## Problem
The REST/UI layer accepts CIDR values in Fail2Ban whitelist, but config generation silently drops them because `Fail2BanConf::initProperty()` validates whitelist entries with `Verify::isIpAddress()`, which only accepts plain IPv4/IPv6 addresses.

As a result:
- plain IPs work;
- CIDR subnets like `10.0.0.0/8` or `10.5.0.0/16` are not added to `ignoreip`.

## Fix
Add a small local validator in `Fail2BanConf` that accepts:
- IPv4
- IPv6
- IPv4 CIDR
- IPv6 CIDR

and use it when building `ignoreip`.

## Validation
Reproduced on a live MikoPBX instance:
- `10.0.0.0/8 10.5.0.0/16 10.44.0.0/16` were accepted by UI but dropped from runtime config before this patch;
- plain IPs were applied correctly;
- after this patch, the mismatch between accepted input and generated config is removed.