### PR TITLE
fix(api): correct getPhonesRepresent guard to reject scalar input (#1040)

### DIFF
--- a/src/PBXCoreREST/Lib/ExtensionsManagementProcessor.php
+++ b/src/PBXCoreREST/Lib/ExtensionsManagementProcessor.php
@@ -66,7 +66,7 @@ class ExtensionsManagementProcessor extends Injectable
                 }
                 break;
             case 'getPhonesRepresent':
-                if (!empty($data['numbers']) || !is_array($data['numbers'])) {
+                if (!empty($data['numbers']) && is_array($data['numbers'])) {
                     $res = Utils::getPhonesRepresent($data['numbers']);
                 } else {
                     $res->messages['error'][] = 'Wrong numbers value in POST/GET data';


### PR DESCRIPTION
## Summary

Fixes #1040.

The guard for the `getPhonesRepresent` action in `ExtensionsManagementProcessor::callBack()` used `||` instead of `&&`, allowing scalar `numbers` values to reach `Utils::getPhonesRepresent(array $numbers)` and crash the `WorkerApiCommands` worker with a `TypeError`.

```diff
 case 'getPhonesRepresent':
-    if (!empty($data['numbers']) || !is_array($data['numbers'])) {
+    if (!empty($data['numbers']) && is_array($data['numbers'])) {
         $res = Utils::getPhonesRepresent($data['numbers']);
     } else {
         $res->messages['error'][] = 'Wrong numbers value in POST/GET data';
     }
     break;
```

## Why this fix and nothing more

- The frontend caller (`extensions-api.js:101-103`) always sends `numbers` as an array, so scalar coercion would only mask buggy callers and broaden the API contract.
- `Utils::getPhonesRepresent(array $numbers)` keeps its strict type hint as defense-in-depth — the controller guard is the right place to reject scalar input cleanly.
- Sibling cases (`available`, `getPhoneRepresent`) were checked and are correct.

## Краткое описание (RU)

Заменено `|| !is_array(...)` на `&& is_array(...)` в guard'е action `getPhonesRepresent`. Теперь скалярный `numbers` отклоняется со штатным сообщением «Wrong numbers value» вместо `TypeError` и краша воркера PBXCoreREST.

## Test plan

- [ ] `POST /pbxcore/api/v3/extensions:getPhonesRepresent` with `data[numbers]=""` → returns structured error, no worker crash.
- [ ] `POST /pbxcore/api/v3/extensions:getPhonesRepresent` with `data[numbers]="201"` (scalar) → returns structured error, no `TypeError` in `php/error.log`.
- [ ] `POST /pbxcore/api/v3/extensions:getPhonesRepresent` with `data[numbers][]=201&data[numbers][]=202` → returns the existing `represent` payload (regression check).

https://claude.ai/code/session_01TPi5Y7mskonGyuaZ26yTcd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPi5Y7mskonGyuaZ26yTcd)_