### PR TITLE
fix(files): stop refusing uploads that send no category

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ for the subtree you touch. Keep this file repo-wide only.
   on the host; `AssetProvider::makeLocalizationAssets()` only regenerates a missing file and
   the version hash ignores translation content.
 - Live paths: DB `/cf/conf/mikopbx.db`; logs under `/storage/usbdisk1/mikopbx/log/`
-  (`system/messages`, `php/error.log`, `nginx/error.log`, `asterisk/`, `fail2ban/`).
+  (`system/messages`, `php/php-error.log`, `nginx/error.log`, `asterisk/`, `fail2ban/`).
 - Module workers crashing 100+ times in 30 min are auto-disabled (`DISABLED_BY_CRASH_LOOP`).
 
 ## Skills

--- a/src/Core/System/ConsoleMenu/Utilities/LogViewer.php
+++ b/src/Core/System/ConsoleMenu/Utilities/LogViewer.php
@@ -41,7 +41,7 @@ class LogViewer
         'asterisk_verbose' => 'asterisk/verbose',
         'asterisk_error' => 'asterisk/error',
         'asterisk_security' => 'asterisk/security_log',
-        'php' => 'php/error.log',
+        'php' => 'php/php-error.log',
         'nginx' => 'nginx/error.log',
         'fail2ban' => 'fail2ban/fail2ban.log',
     ];

--- a/src/PBXCoreREST/Lib/Files/UploadFileAction.php
+++ b/src/PBXCoreREST/Lib/Files/UploadFileAction.php
@@ -53,6 +53,10 @@ class UploadFileAction extends Injectable
     // MIME types allowed for different categories
     private const ALLOWED_MIME_TYPES = [
         'sound' => [
+            // A plain multipart POST (curl, a module) carries no type at all;
+            // the audio extension whitelist and the post-merge magic-byte check
+            // still apply, and the declared MIME is client-supplied regardless.
+            '',
             'audio/mpeg',
             'audio/wav',
             'audio/ogg',
@@ -399,7 +403,7 @@ class UploadFileAction extends Injectable
     private static function validateFileType(string $filename, string $mimeType, string $category): array
     {
         $validationCategory = self::normalizeCategory($category);
-        if ($validationCategory === null) {
+        if ($validationCategory === null && !self::isUnspecifiedCategory($category)) {
             return ['valid' => false, 'error' => "Unknown upload category: $category"];
         }
 
@@ -424,7 +428,7 @@ class UploadFileAction extends Injectable
         }
 
         // 2. Check MIME type for category
-        if (isset(self::ALLOWED_MIME_TYPES[$validationCategory])) {
+        if ($validationCategory !== null && isset(self::ALLOWED_MIME_TYPES[$validationCategory])) {
             if (!in_array($mimeType, self::ALLOWED_MIME_TYPES[$validationCategory], true)) {
                 $error = Util::translate(
                     'sf_UploadInvalidMimeType',
@@ -493,7 +497,9 @@ class UploadFileAction extends Injectable
     {
         $validationCategory = self::normalizeCategory($category);
         if ($validationCategory === null) {
-            return ['valid' => false, 'error' => "Unknown upload category: $category"];
+            return self::isUnspecifiedCategory($category)
+                ? ['valid' => true]
+                : ['valid' => false, 'error' => "Unknown upload category: $category"];
         }
 
         // Firmware and CSV content cannot be identified reliably by a short
@@ -559,6 +565,21 @@ class UploadFileAction extends Injectable
     private static function isAllowedAudioExtension(string $extension): bool
     {
         return in_array(strtolower($extension), self::AUDIO_EXTENSIONS, true);
+    }
+
+    /**
+     * A client that sends no category at all gets the category-specific checks
+     * skipped, not a hard refusal: `category` is declared neither in the
+     * endpoint's OpenAPI parameters nor on the sound-files upload route, so
+     * requiring it would break every pre-existing API client and module.
+     * The controls the security audit relies on do not depend on it: the
+     * forbidden extension list and the .img guard still run, the file always
+     * lands in upload-cache, and ConvertAudioFileAction re-validates path,
+     * category and audio content before mv/FFmpeg ever see it.
+     */
+    private static function isUnspecifiedCategory(string $category): bool
+    {
+        return $category === '' || $category === 'unknown';
     }
 
     private static function normalizeCategory(string $category): ?string

--- a/src/PBXCoreREST/Lib/SoundFiles/UploadFileAction.php
+++ b/src/PBXCoreREST/Lib/SoundFiles/UploadFileAction.php
@@ -54,8 +54,10 @@ class UploadFileAction
         // Use the existing Files upload mechanism
         $category = $data['category'] ?? SoundFiles::CATEGORY_CUSTOM;
         
-        // Call the existing upload action
-        $uploadResult = FilesUploadFileAction::main($data);
+        // Call the existing upload action. The route already states the category,
+        // so clients need not repeat it in the body: pass the resolved one down
+        // rather than letting the shared action fall back to 'unknown'.
+        $uploadResult = FilesUploadFileAction::main($data + ['category' => $category]);
         
         if ($uploadResult->success && !empty($uploadResult->data['upload_file_path'])) {
             // Create or update sound file record

--- a/tests/Unit/PBXCoreREST/Lib/Files/UploadFileActionSecurityTest.php
+++ b/tests/Unit/PBXCoreREST/Lib/Files/UploadFileActionSecurityTest.php
@@ -23,9 +23,63 @@ class UploadFileActionSecurityTest extends TestCase
         return $method->invoke(null, $filename, $mimeType, $category);
     }
 
-    public function testUnknownUploadCategoryIsRejected(): void
+    /**
+     * @dataProvider unspecifiedCategoryProvider
+     */
+    public function testUnspecifiedCategorySkipsCategoryChecks(string $category): void
     {
-        $this->assertFalse($this->validate('payload.bin', 'application/octet-stream', 'unknown')['valid']);
+        $this->assertTrue($this->validate('payload.bin', 'application/octet-stream', $category)['valid']);
+    }
+
+    /**
+     * The forbidden-extension list does not depend on the category, so a
+     * client that sends none still cannot upload executable content.
+     *
+     * @dataProvider unspecifiedCategoryProvider
+     */
+    public function testUnspecifiedCategoryStillBlocksForbiddenExtensions(string $category): void
+    {
+        $this->assertFalse($this->validate('shell.php', 'application/octet-stream', $category)['valid']);
+        $this->assertFalse($this->validate('mikopbx.img', 'application/octet-stream', $category)['valid']);
+    }
+
+    public static function unspecifiedCategoryProvider(): array
+    {
+        return [['unknown'], ['']];
+    }
+
+    public function testNamedUnrecognizedCategoryIsRejected(): void
+    {
+        $result = $this->validate('payload.bin', 'application/octet-stream', 'temp');
+        $this->assertFalse($result['valid']);
+        $this->assertSame('Unknown upload category: temp', $result['error']);
+    }
+
+    public function testMagicBytesValidationSkipsUnspecifiedCategory(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'upload-test-');
+        file_put_contents($file, "not audio at all\n");
+
+        try {
+            $this->assertTrue(UploadFileAction::validateMagicBytes($file, 'unknown')['valid']);
+            $this->assertFalse(UploadFileAction::validateMagicBytes($file, 'temp')['valid']);
+            // A named category is still content-checked - this is what proves
+            // the permissive branch above did not leak into the general case.
+            $this->assertFalse(UploadFileAction::validateMagicBytes($file, 'sound')['valid']);
+        } finally {
+            unlink($file);
+        }
+    }
+
+    /**
+     * A client posting a plain multipart body sends no MIME type; the sound
+     * route supplies the category itself, so such an upload must not 422.
+     */
+    public function testSoundAcceptsUploadWithoutMimeType(): void
+    {
+        $this->assertTrue($this->validate('prompt.wav', '', 'sound')['valid']);
+        $this->assertTrue($this->validate('prompt.wav', '', 'custom')['valid']);
+        $this->assertFalse($this->validate('prompt.exe', '', 'sound')['valid']);
     }
 
     public function testResumableBrowserMimeTypeIsRecognized(): void

--- a/tests/api/helpers/test_runner.py
+++ b/tests/api/helpers/test_runner.py
@@ -262,7 +262,7 @@ class TestRunner:
         # Check PHP error log
         print(f"🔍 Checking PHP error log (last {lines} lines)...")
         php_errors = self._get_log_errors(
-            '/storage/usbdisk1/mikopbx/log/php/error.log',
+            '/storage/usbdisk1/mikopbx/log/php/php-error.log',
             lines
         )
         errors['php_errors'] = php_errors

--- a/tests/api/test_41_syslog.py
+++ b/tests/api/test_41_syslog.py
@@ -51,7 +51,7 @@ class TestSyslog:
         test_files = [
             'asterisk/messages',
             'system/messages',
-            'php/error.log',
+            'php/php-error.log',
             'nginx/error.log'
         ]
 

--- a/tests/api/test_53_system_health.py
+++ b/tests/api/test_53_system_health.py
@@ -209,10 +209,11 @@ class TestAudioConversionPipeline:
         self.__class__.test_file_path = target_path
 
         # Upload the file using files:upload, then copy to monitor dir
+        # No category: a .wav48 fixture is not a sound-file upload, and an
+        # unrecognized category is refused outright.
         upload_response = api_client.upload_file(
             'files:upload',
-            str(SAMPLE_WAV48),
-            params={'category': 'temp'}
+            str(SAMPLE_WAV48)
         )
         assert_api_success(upload_response, "Failed to upload wav48 fixture")
 

--- a/tests/api/test_98_log_analysis.py
+++ b/tests/api/test_98_log_analysis.py
@@ -34,7 +34,7 @@ CONVERSION_TASKS_DIR = '/storage/usbdisk1/mikopbx/astspool/monitor/conversion-ta
 # Log files to analyze
 LOG_FILES = {
     'system': '/storage/usbdisk1/mikopbx/log/system/messages',
-    'php_error': '/storage/usbdisk1/mikopbx/log/php/error.log',
+    'php_error': '/storage/usbdisk1/mikopbx/log/php/php-error.log',
 }
 
 # Error patterns categorized by severity
@@ -78,7 +78,9 @@ def exec_bash(api_client, command: str, timeout: int = 30) -> dict:
 
 def get_log_line_count(api_client, log_path: str) -> int:
     """Get current line count of a log file."""
-    result = exec_bash(api_client, f'wc -l < "{log_path}" 2>/dev/null || echo 0')
+    # `wc -l < missing` fails in the shell itself, so its "can't open" message
+    # lands in stdout ahead of the fallback 0. Pipe instead of redirect.
+    result = exec_bash(api_client, f'cat "{log_path}" 2>/dev/null | wc -l')
     return int(result['output'].strip())
 
 


### PR DESCRIPTION
## Problem

`aa9a4cdf2` (part of the 25–27.08 security batch) made `normalizeCategory()` return `null` for
any category outside the fixed list, and both `validateFileType()` and `validateMagicBytes()`
then fail hard. Since `$category = $parameters['category'] ?? 'unknown'`, a client that sends no
category at all gets **HTTP 422**.

That turned an undocumented parameter into a required one:

- `category` appears in no `ApiParameterRef` on `Files\RestController`, and not in the endpoint's
  own curl example (`RestController.php:61`);
- `sound-files:uploadFile` passed `$data` straight through without supplying a category, even
  though the route itself implies one;
- modules and third-party clients built before 25.08 had no reason to send it.

The admin cabinet was repaired separately in `500ed10da`, so the UI is unaffected; everything
else has been getting 422 since. `Mikopbx_RestAPITestsOn172163272` has been red since build 48411
(26.08) with `test_51_files::test_03`, `test_53_system_health::test_01` and the cascading
`test_03`.

## Why relaxing this does not weaken the audit fixes

The category is client-supplied and does not influence where the file lands — it is always
`{uploadDir}/{resumableIdentifier}`. The controls that matter run regardless:

- the forbidden-extension list, the `.img`-only-for-firmware guard and the `resumableIdentifier`
  sanitization are category-independent;
- `category=firmware` already whitelists `application/octet-stream` and has no magic-byte
  prefixes, so a hostile client uses that rather than an unknown category;
- for the audio path the load-bearing control is `ConvertAudioFileAction::validateUploadedSource()`
  — realpath confinement to upload-cache, category restricted to `custom`/`moh`, and
  `validateAudioFile()` — all re-derived immediately before `mv`/FFmpeg, independent of what was
  declared at upload time.

What a category-less upload does lose is `validateSvgContent()`. No core consumer reaches it
today (upload-cache is not web-served), and `category=firmware` already bypasses it.

## Changes

- `UploadFileAction`: an absent or `'unknown'` category skips the category-specific checks again;
  a **named** unrecognized category is still refused.
- `SoundFiles\UploadFileAction`: passes the category it already resolves (`custom` by default)
  down to the shared action instead of letting it fall back to `'unknown'`.
- `ALLOWED_MIME_TYPES['sound']` accepts an empty MIME type, the way `firmware` does — a plain
  multipart POST that declares no type must not 422 now that the route supplies the category.
- PHP log path: `php/error.log` → `php/php-error.log` in `LogViewer`, three test files and
  `AGENTS.md`. `PHPConf::generateSyslogConf()` binds rsyslog's `programname == "php"` to
  `PHPConf::getLogFile()`, which is `.../log/php/php-error.log` — the console menu's "PHP log"
  entry was reading a file that never exists.
- `test_98_log_analysis`: `wc -l < missing` fails in the shell itself, so its "can't open"
  message landed in stdout ahead of the fallback `0` and broke `int()`. Piped instead.
- `test_53_system_health`: dropped the `category: 'temp'` parameter.

## Verification

- `vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/PBXCoreREST/Lib/Files` inside
  `mikopbx/mikopbx:latest` — 21 tests, 33 assertions, OK.
- `vendor/bin/phpstan analyse` — no errors in the touched files.
- New regression coverage: unspecified category passes but `.php`/`.img` are still blocked; a
  named unrecognized category is refused; magic bytes are skipped for an unspecified category and
  still enforced for `sound`; `sound` without a MIME type passes while `.exe` does not.

Not verified live against a stand — no API credentials for 172.16.33.72 here. The first CI run on
this branch is the real check.

## Note

`tests/Unit/PBXCoreREST/Lib/SoundFiles/ConvertAudioFileActionGuardTest.php:28` declares `setUp()`
as `protected` while `AbstractUnitTest` declares it `public`, which kills the whole subtree with a
fatal error. Pre-existing on `develop`, untouched here.
