### PR TITLE
test(unit): unblock the whole PBXCoreREST unit subtree

### DIFF
--- a/tests/Unit/AbstractUnitTest.php
+++ b/tests/Unit/AbstractUnitTest.php
@@ -13,7 +13,7 @@ abstract class AbstractUnitTest extends UnitTestCase
 {
     private bool $loaded = false;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $di = new FactoryDefault\Cli();

--- a/tests/Unit/PBXCoreREST/Lib/SoundFiles/ConvertAudioFileActionGuardTest.php
+++ b/tests/Unit/PBXCoreREST/Lib/SoundFiles/ConvertAudioFileActionGuardTest.php
@@ -177,20 +177,26 @@ class ConvertAudioFileActionGuardTest extends AbstractUnitTest
             $sourceFile,
             'Original .ogg must be removed once all targets are produced successfully'
         );
-        $this->assertFileExists($this->tmpDir . '/upload.mp3');
-        $this->assertGreaterThan(0, filesize($this->tmpDir . '/upload.mp3'));
+        $this->assertFileExists($this->tmpDir . '/upload.webm');
+        $this->assertGreaterThan(0, filesize($this->tmpDir . '/upload.webm'));
+        // WebM is the canonical path handed back to the caller.
+        $this->assertSame($this->tmpDir . '/upload.webm', $result->data[0]);
     }
 
     /**
      * Original file path differs only in case from the produced target path
-     * (.MP3 source vs .mp3 target on case-insensitive matching). The gate must
+     * (.WAV source vs .wav target on case-insensitive matching). The gate must
      * recognise them as the same logical file and refuse to delete the source.
+     *
+     * Needs a case-sensitive filesystem (the container) to exercise the
+     * strcasecmp branch; on a case-insensitive host the two names are one file
+     * and the realpath comparison short-circuits first.
      */
     public function testOriginalPreservedWhenOnlyExtensionCaseDiffers(): void
     {
         $this->installStubs('eval "dest=\\${$#}"; head -c 1024 /dev/zero > "$dest"; exit 0');
 
-        $sourceFile = $this->tmpDir . '/UPLOAD.MP3';
+        $sourceFile = $this->tmpDir . '/UPLOAD.WAV';
         file_put_contents($sourceFile, 'orig');
 
         $result = ConvertAudioFileAction::convertAudioFile($sourceFile);
@@ -198,10 +204,10 @@ class ConvertAudioFileActionGuardTest extends AbstractUnitTest
         $this->assertStubFired();
         $this->assertTrue($result->success);
         // The lowercase target was created…
-        $this->assertFileExists($this->tmpDir . '/UPLOAD.mp3');
+        $this->assertFileExists($this->tmpDir . '/UPLOAD.wav');
         // …but the original (case-different) file must NOT be removed by the gate
         // because it is logically the same file and removing it would orphan the
-        // SoundFiles DB row that still points to UPLOAD.MP3.
+        // SoundFiles DB row that still points to UPLOAD.WAV.
         $this->assertFileExists(
             $sourceFile,
             'Case-only mismatch between source and target must be treated as same file'

--- a/tests/Unit/phpunit.xml
+++ b/tests/Unit/phpunit.xml
@@ -17,5 +17,11 @@
           processIsolation="true"
           stopOnFailure="false" 
           >
-
+    <php>
+        <!-- LoggerProvider adds LOG_PERROR unless this is set, and syslog then
+             echoes every logged line to stderr. With processIsolation the child
+             process's stderr is treated as a test error, so any code path that
+             logs a warning fails the test that exercises it. -->
+        <env name="SUPPRESS_CONSOLE_LOGS" value="1" force="true"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
## Problem

`AbstractUnitTest` declares `setUp()` as `public`, while `Incubator\PHPUnit\UnitTestCase` and
PHPUnit's own `TestCase` declare it `protected`. Any subclass written with the conventional
`protected` signature is therefore a **fatal error at class-declaration time** — and that fatal
takes down the whole run, not just the offending file:

```
$ vendor/bin/phpunit -c tests/Unit/phpunit.xml tests/Unit/PBXCoreREST
Fatal error: Access level to ...ConvertAudioFileActionGuardTest::setUp() must be public
             (as in class MikoPBX\Tests\Unit\AbstractUnitTest)
```

So `tests/Unit/PBXCoreREST` — 218 tests — has not been runnable at all.

## Changes

**1. Narrow the base class instead of widening the subclasses.** `AbstractUnitTest::setUp()`
becomes `protected`, matching its own parent and PHPUnit. Seventeen subclasses already use
`protected`; the four that use `public` keep working, because widening visibility in a child is
legal in PHP.

**2. `SUPPRESS_CONSOLE_LOGS` in `phpunit.xml`.** With the file finally running, two of its tests
failed for an unrelated reason: `LoggerProvider` adds `LOG_PERROR` unless that env var is set, so
syslog echoes every logged line to stderr, and with `processIsolation="true"` PHPUnit treats a
child process's stderr as a test error. The practical effect is that **any** code path calling
`SystemMessages::sysLogMsg()` fails the test exercising it. The switch already exists in
production code, so no test-only flag is invented; `force="true"` keeps an exported empty value in
someone's shell from silently defeating it.

**3. Fix two assertions that could never pass.** `ConvertAudioFileActionGuardTest` expected `.mp3`
outputs, but `ConvertAudioFileAction::convertAudioFile()` produces `webm, wav, ulaw, alaw, gsm,
g722, sln` — never mp3. Retargeted to `.webm` (the canonical path returned in `data[0]`), and the
"case-only difference" test now uses a `.WAV` source colliding with the real `.wav` target — with
`.MP3` there was no matching target at all, so the `strcasecmp` branch the docblock describes was
unreachable and the test could not have tested it.

## Verification

- `tests/Unit/PBXCoreREST/Lib/SoundFiles` — 10 tests, 31 assertions, **OK** (was: fatal error).
- `tests/Unit/PBXCoreREST` — 218 tests now execute, 215 pass.
- All runs inside `mikopbx/mikopbx:latest`, per `AGENTS.md`.

## Pre-existing failures, not touched here

Verified by running each on the **untouched** checkout in the same container — they reproduce
identically and are simply invisible today behind the fatal:

- `ModuleExtensionOwnerResolverTest::testIgnoresRelationsThatDoNotIdentifyAModule`
- `GetDetailedPermissionsActionTest::testPublishesOnlyOverriddenLegacyRestCallbacks`
- `FirmwareUpgradeShellScriptsTest::testFirmwareUpgradeDoesNotProbeSerialPortsByWritingToThem`

Also unchanged: `tests/Unit/Common` and `tests/Unit/Core` still die with `Cannot redeclare class
ComposerAutoloaderInit...` because a test's `require_once 'Globals.php'` pulls in the container's
own `/offload/rootfs/usr/www/vendor` autoloader. Identical on the untouched checkout.

## Noted, out of scope

`tests/AdminCabinet/Tests/Traits/EntityCreationTrait.php:53` calls `$testInstance->setUp()`
externally, but `MikoPBXTestsBase::setUp()` is already `protected` — a latent `Error` that the
surrounding `catch (\Exception $e)` would not even catch. Predates this PR; worth its own ticket.
