### PR TITLE
test: base manual time on PBX clock and accept live session on re-login

### DIFF
--- a/tests/AdminCabinet/Tests/FillDataTimeSettingsTest.php
+++ b/tests/AdminCabinet/Tests/FillDataTimeSettingsTest.php
@@ -58,6 +58,12 @@ class FillDataTimeSettingsTest extends MikoPBXTestsBase
         $this->waitForAjax();
         sleep(2);
 
+        // The PBX parses ManualDateTime in its own timezone, so take the base time from the
+        // PBX clock on the page, not from the test runner (UTC in CI shifted the PBX by hours)
+        if ($params[PbxSettings::PBX_MANUAL_TIME_SETTINGS]) {
+            $params['ManualDateTime'] = $this->getPbxTimeWithOffset($params['ManualDateTime']);
+        }
+
         // Set timezone and other settings
         $this->selectDropdownItem(PbxSettings::PBX_TIMEZONE, $params[PbxSettings::PBX_TIMEZONE]);
         $this->changeCheckBoxState(PbxSettings::PBX_MANUAL_TIME_SETTINGS, $params[PbxSettings::PBX_MANUAL_TIME_SETTINGS]);
@@ -172,6 +178,29 @@ JS
         );
     }
 
+    /**
+     * Returns the PBX time shown on the page shifted by a strtotime() offset, e.g. '+5 minutes'
+     */
+    protected function getPbxTimeWithOffset(string $offset): string
+    {
+        // Until the timezone is loaded the clock worker formats time in the browser's zone;
+        // the caller's waitForAjax() + sleep(2) lets at least one tick run after that
+        $pbxNow = self::$driver->wait(30, 500)->until(
+            static fn() => self::$driver->executeScript(
+                "return document.querySelector('#PBXTimezone').value
+                    && document.querySelector('#CurrentSystemTime').value;"
+            )
+        );
+
+        // UTC is only a neutral zone for the arithmetic, so DST cannot skew the offset
+        $time = \DateTime::createFromFormat('Y-m-d H:i:s', $pbxNow, new \DateTimeZone('UTC'));
+        if ($time === false) {
+            self::fail("Unexpected PBX time format: {$pbxNow}");
+        }
+
+        return $time->modify($offset)->format('Y-m-d H:i:s');
+    }
+
     protected function isLoginPageDisplayed(): bool
     {
         return (bool) self::$driver->executeScript(
@@ -247,7 +276,7 @@ JS
         }
 
         // Manual mode - check the time difference
-        // Format is now 'Y-m-d H:i:s' (e.g., '2025-10-15 14:30:00')
+        // Provider holds a strtotime() offset (e.g., '+5 minutes')
         $manualDateTime = $params['ManualDateTime'];
         $targetTime = strtotime($manualDateTime);
         $currentTime = time();
@@ -416,13 +445,13 @@ JS
         // Changes time by +5 minutes - should NOT require re-login
         // JWT access tokens remain valid (exp + 600 > current_time)
         // Redis refresh tokens unaffected (TTL is time-independent)
-        // Format MUST match time-settings-worker.js:117 -> 'YYYY-MM-DD HH:mm:ss'
+        // ManualDateTime is an offset from the PBX clock, resolved by getPbxTimeWithOffset()
         $params[] = [
             [
                 PbxSettings::PBX_TIMEZONE => 'Europe/Riga',
                 'PBXTimezone' => 'Europe/Riga', // Ensure we have the same value for verification
                 PbxSettings::PBX_MANUAL_TIME_SETTINGS => true,
-                'ManualDateTime' => date('Y-m-d H:i:s', strtotime('+5 minutes')),
+                'ManualDateTime' => '+5 minutes',
                 PbxSettings::NTP_SERVER => '',
             ],
         ];

--- a/tests/AdminCabinet/Tests/Traits/LoginTrait.php
+++ b/tests/AdminCabinet/Tests/Traits/LoginTrait.php
@@ -69,6 +69,11 @@ trait LoginTrait
             usleep(500000); // 500ms
 
             if (!$this->isLoginFormPresent()) {
+                // A live session is redirected from /session/index to the home page
+                if ($this->isUserLoggedIn()) {
+                    $this->assertTrue(true);
+                    return;
+                }
                 throw new RuntimeException('Login form not found after page refresh');
             }
         }


### PR DESCRIPTION
## Problem
`FillDataTimeSettingsTest` (data set #0) flaked in 4 of the last 15 UI builds (latest: 2026.4.19-dev).

- The provider built `ManualDateTime` from the CI runner clock, which is UTC. The PBX parses the value in its own timezone (`UpdateSettingsAction::updateSystemTime()` → `strtotime()`), so the PBX clock jumped by −3h instead of +5 min (stand log: `TimeSettingsManagementProcessor::update (execution: -10854.533s)`). JWT was invalidated and the session logged out.
- Re-login attempt 1 did succeed on the server, but the home page returned 502 while php-fpm restarted. Attempts 2–3 opened `/session/index` while already authenticated, got redirected to the home page, and threw `Login form not found after page refresh`.

## Fix
- `ManualDateTime` is now an offset (`'+5 minutes'`) applied to the PBX clock shown on the page (`#CurrentSystemTime`, read once `#PBXTimezone` is loaded).
- `LoginTrait::performLogin`: when there is no login form after a refresh but the user is logged in, treat it as success.

## Verification
- `php -l`, phpcs (no new PSR-12 findings), code review.
- Not yet run on BrowserStack. To check on stand 172.16.33.72: run `PHPUNIT_FILTER=testChangeDataTimeSettings`. Expect `TimeSettings…update (execution: ~300s)` in `messages`.