### PR TITLE
fix(sound-files): keep read-only path in response schemas

### DIFF
--- a/src/PBXCoreREST/Lib/SoundFiles/DataStructure.php
+++ b/src/PBXCoreREST/Lib/SoundFiles/DataStructure.php
@@ -150,7 +150,7 @@ class DataStructure extends AbstractDataStructure implements OpenApiSchemaProvid
         }
 
         // ✨ Inherit response-only fields for list (NO duplication!)
-        $listResponseFields = ['id', 'fileSize', 'duration'];
+        $listResponseFields = ['id', 'path', 'fileSize', 'duration'];
         foreach ($listResponseFields as $field) {
             if (isset($responseFields[$field])) {
                 $properties[$field] = $responseFields[$field];

--- a/tests/Unit/PBXCoreREST/Lib/SoundFiles/DataStructureSecurityTest.php
+++ b/tests/Unit/PBXCoreREST/Lib/SoundFiles/DataStructureSecurityTest.php
@@ -17,4 +17,11 @@ final class DataStructureSecurityTest extends TestCase
         self::assertTrue($definitions['response']['path']['readOnly']);
         self::assertArrayHasKey('conversion_id', $definitions['request']);
     }
+
+    public function testReadOnlyPathStaysInResponseSchemas(): void
+    {
+        // Responses still carry path; strict schema validation turns its absence into 422
+        self::assertArrayHasKey('path', DataStructure::getListItemSchema()['properties']);
+        self::assertArrayHasKey('path', DataStructure::getDetailSchema()['properties']);
+    }
 }


### PR DESCRIPTION
02de45024 marked `SoundFiles.path` as `readOnly`, which dropped it from the request definitions that `getListItemSchema()` / `getDetailSchema()` are built from. Responses still carry `path`, so `ResponseSchemaValidator` reports `[SCHEMA VALIDATION FAILED] Field 'path' is present in response but not defined in schema`.

With `SCHEMA_VALIDATION_STRICT=1` (ARM64 Docker REST API run in TeamCity) that becomes 422 on `GET /sound-files`, `/sound-files/{id}` and `:getDefault` — 9 failed tests in builds 48929/48972, blocking NightlyDeploy.

`path` stays out of the request section; a unit test now asserts it is present in both response schemas.